### PR TITLE
中間テーブルのdropを修正

### DIFF
--- a/apps/kita/database/migrations/2023_08_07_071609_article_article_tag.php
+++ b/apps/kita/database/migrations/2023_08_07_071609_article_article_tag.php
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('article_tags');
+        Schema::dropIfExists('article_article_tag');
     }
 };


### PR DESCRIPTION
概要
php artisan migrate:refresh --seedでエラーが出ないようにマイグレーションファイルを修正しました。

受け入れ基準
php artisan migrate:refresh --seedでエラーにならないこと

具体的な変更点
・中間テーブルのdropを適切なテーブル名に変更

関連チケット
https://fullspeed.atlassian.net/browse/WVQS-51

機能画画像
<img width="1213" alt="スクリーンショット 2023-08-14 18 11 51" src="https://github.com/arimurashoi2000/newestKita/assets/126123174/e170c7f8-d01d-42fc-a9f4-56fd7b7631f3">
